### PR TITLE
Ops: improve documentation

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,47 @@
+# Deployment
+
+This is a python FastAPI app that is built to run on AWS Lambda
+via the API Gateway.
+It should also be able to run on other platforms
+(such as MS Azure, or any platform supporting docker containers)
+although those are not currently being actively tested
+by the development team. 
+
+Deployments are managed with the `serverless` tool,
+which manges dealing underlying platform.
+
+For first time installation, you have to use the coordination service 
+[here](https://github.com/ACWIC/training-provider-coordinator)
+
+it's responsible for installing everything on AWS for the first time.
+It's also responsible for creating S3 buckets needed for this service to run.
+
+
+## Continuous Delivery
+After the first deployment, you can either enable the CI/CD pipeline using
+the provided `.circleci` configuration or you can deploy manually using 
+the commands in `Makefile` file.
+
+The command `make deploy_lambda` deploys your local
+version directly to AWS lambda.
+
+## Configuration:
+
+#### AWS CLI:
+to be able to use serverless or `make deploy_lambda` commands, you need to have
+the aws cli set up locally, with an AWS default profile enabled.
+You can consult the AWS configuration for more details.
+
+There's two expected environment variables [managed by serverless on AWS]:
+
+`STAGE_PREFIX`: API gateways add a prefix after the domain, but it's not passed down to the service.
+But if the service is called from a Javascript application like swagger UI, the prefix has be provided.
+`STAGE_PREFIX` should is expected to be provided by the serverless runner.
+
+
+`SERVICE_PREFIX`: When deploying more than one service under the same API gateway, a prefix is used to
+map to each service. this prefix is passed to the service itself, and all URLs are expected to be prepended
+with it. (unlike the `STAGE_PREFIX`)
+
+Note that all both variables are managed and provided from serverless, and you don't need to think about them
+during development.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,64 @@
+# Development
+
+This is a python FastAPI app
+built in the "clean architecture" style
+(using functionally pure domain entities,
+repository objects that encapsulate IO,
+use-case classes that encapsulate business logic, etc).
+
+See [DEPLOYMENT.md](DEPLOYMENT.md) for instructions on how to deploy this service
+
+---
+
+## Collaboration
+We work in GitHub with a [github flow](https://guides.github.com/introduction/flow/),
+and require all PR's to be reviewed before merging.
+There are also guard-rails preventing merges
+that violate test coverage or code style policies,
+or failing tests.
+
+
+## Coding Style guide
+
+We use pre-commit hooks, including black, isort, flake8.
+
+The suggested way to install these hooks it is by installing [pre-commit](https://pre-commit.com/), 
+
+then running `pre-commit install`
+
+Note that on the first time you run `git commit`,
+it's going to  take some time to install all the hooks,
+but after that it will be fast.
+
+## Local development
+
+Everything is managed with `docker-compose`. The configuration for this is stored in
+`local.yml`, so it can be convenient to set this in your shell first:
+```
+export COMPOSE_FILE=local.yml
+```
+
+1. `docker-compose build` - build everything
+2. `docker-compose up -d` - run everything in daemon mode
+
+There are two components:
+2. API documentation (via uvicorn/FastAPI directly)
+3. minio (mimics AWS lambda)
+
+
+## Configuration
+Default configuration is provided under `.envs/.local/`, which includes
+everything required for the components to work together.
+
+## Tests
+Tests are managed with pytest, which can be executed with the shortcut make command:
+```
+make test
+```
+
+**A note about local resources:**
+
+docker-compose will not auto-create S3 buckets in minio,
+so this must be done manually first.
+See the configuration in .envs/.local/.sls
+to determine what buckets are needed.

--- a/README.md
+++ b/README.md
@@ -1,83 +1,34 @@
 # Training Provider Admin API
+[![codecov](https://codecov.io/gh/ACWIC/training-provider-admin/branch/main/graph/badge.svg?token=JUR2RGTRN9)](undefined)
+[![CircleCI](https://circleci.com/gh/ACWIC/training-provider-admin.svg?style=svg&circle-token=540486bf1e2e1651b8d860d48a41e2966fd7b936	)](https://circleci.com/gh/circleci/circleci-docs)
 
-This is a FastAPI app that is built to run on AWS Lambda via the API Gateway.
-It is deployed with the `serverless` tool, which manges dealing with AWS. It can
-also run locally with `serverless-offline` in a mode which mimics API Gateway/lambda
-infrastructure. This mode leverages local services like Minio as replacements for 
-AWS resources like S3.
+This is a reference implementation of a proposed API
+enabling Training Providers to interact with Aged Care Providers
+(employers) in a standardised way.
 
-## Installation
+Specifically, it provides the endpoints for the training provider to manage
+their course catalogue, so that customers (Aged Care Providers i.e. employers)
+can search and browse for courses that match their requirements 
+(using the Training Provider Catalogue service), so that they can
+procure training services (using the Training Provider Enrolment service)
 
-Everything is managed with docker-compose. The configuration for this is stored in
-`local.yml`, so it can be convenient to set this in your shell first:
-```
-export COMPOSE_FILE=local.yml
-```
+This is a companion service to 
+- [Training Provider Catalogue](https://github.com/ACWIC/training-provider-catalogue)
+- [Training Provider Enrolment](https://github.com/ACWIC/training-provider-enrolment)
 
-1. `docker-compose build` - build everything
-2. `docker-compose up -d` - run everything in daemon mode
+[DEVELOPMENT.md](DEVELOPMENT.md) and [DEPLOYMENT.md](DEPLOYMENT.md)
+contain information about running
+the software and making changes to it.
 
-There are three components:
-1. serverless
-2. API documentation (via uvicorn/FastAPI directly)
-3. minio
-
-## Configuration
-
-Default configuration is provided under `.envs/.local/`, which includes
-everything required for the components to work together. These variables
-are also used to configure the serverless stages (local, dev).
-
-Serverless additionally needs AWS credentials in order to deploy. This can be provided
-either automatically via the `~/.aws` home directory, which is mounted to the container
-home directory, or via AWS environment variables provided in `.env`.
-
-## Serverless
-
-This component is used to containerise serverless build tooling. It is a python3.8 image
-with node v12.x installed in order to run the serverless CLI tool. Serverless is responsible
-for building and packaging the underlying python app, but also can serve a local version via
-the `offline` command, which is the default command when bringin the container up.
-
-The entrypoint for the container is `serverless`, so this container can be used to do most things
-that the `serverless` CLI tool can.
-
-The `serverless.yml` file is used to configure the CLI, and defines all of the endpoints,
-resources, IAM policies and stages. The configuration file defines stages that map to
-deployed stages (e.g. dev) as well as a local stage which is used to provide configuration
-for serverless-offline.
-
-### Running locally
-```
-docker-compose up -d serverless
-```
-
-This command will run the container in offline mode on port 3000, using `serverless-offline`.
-This plugin mimics the API gateway and lambda context which the deployed code would operate
-in, which is particularly helpful for debugging the interface between code and infrastructure.
-The offline runner uses the API gateway configuration described in serverless.yml (the same that
-is used to deploy with).
-
-**A note about local resources**
-
-Serverless will not auto-create S3 buckets in minio, so this must be done manually first.
-
-### Deploying
-```
-docker-compose run --rm serverless deploy --stage dev
-```
-
-This command packages the app with configuration defined in the serverless dev stage. Serverless
-will use AWS credentials in one of two locations:
-- in the user's aws directory `~/.aws`
-- a `.env` with the following variables defined:
-  - `AWS_ACCESS_KEY_ID`
-  - `AWS_SECRET_ACCESS_KEY`
+There is a test endpoint with a self-documenting API specification 
+[here](https://j7ndza0k1j.execute-api.us-east-1.amazonaws.com/dev/admin/docs)
 
 
-## Tests
+This is equivalent to what you will have running locally
+if you create a local development environment
+(per [DEVELOPMENT.md](DEVELOPMENT.md))
 
-Tests are run with pytest, which can be executed with the following command:
-```
-docker-compose run --rm test
-```
+The test endpoint is continuously deployed
+from the `main` branch in this repository, so should be considered unstable.
+It is also completely open (do not require authentication),
+which is not a realistic simulation of any kind of production environment.


### PR DESCRIPTION
Following https://github.com/ACWIC/employer-callback/pull/17/ 
This PR adds development and deployment instructions. 

I've changed the format a little bit, moving instructions for local environment setup into `DEVELOPMENT.md` since it's more related to development than deployment. 

My intuition is that the first step for new developers in a project is usually to run the project locally to set how it works, that's why it makes more sense to me to put this in the `DEVELOPMENT.md` rather than `DEPLOYMENT.md`

Once this PR is approved, I'll replicate it everywhere.